### PR TITLE
fix input operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,3 +170,17 @@ Here is an operator conversion table.
 |`]`|`:\|`|
 |`,`|`v`|
 |`.`|`X`|
+
+# development
+
+- test
+
+```bash
+npm run test
+```
+
+- run locally
+
+```
+npm run dev
+```

--- a/src/components/organisms/Mode.tsx
+++ b/src/components/organisms/Mode.tsx
@@ -40,7 +40,7 @@ function Mode() {
         return
       }
 
-      if (state.chord === "X") {
+      if (state.chord === "X" || state.chord === "v") {
         setChord(metaChords.REST)
         return
       }

--- a/src/modules/cholc/chord.ts
+++ b/src/modules/cholc/chord.ts
@@ -58,13 +58,13 @@ export function chordName(code: ByteCode): string {
     // rest
     case byteCodes.Output:
       return "X"
-    
+    case byteCodes.Input:
+      return "v"
+
     // other special codes
     case byteCodes.StartLoop:
       return "unknown"
     case byteCodes.EndLoop:
-      return "unknown"
-    case byteCodes.Input:
       return "unknown"
     case byteCodes.Unknown:
       return "unknown"

--- a/src/modules/cholc/evaluate.ts
+++ b/src/modules/cholc/evaluate.ts
@@ -27,7 +27,6 @@ export class Evaluator {
   }
 
   step(): CholcState {
-    this.inputChar()
     this.handleLoop()
 
     if (this.pc >= this.program.length) {
@@ -44,6 +43,7 @@ export class Evaluator {
     this.updateMemory()
 
     this.outputChar()
+    this.inputChar()
 
     this.pc++
 
@@ -56,13 +56,10 @@ export class Evaluator {
   }
 
   private inputChar() {
-    // NOTE: unlike output(`X`), input(`v`) is consumed instantly and the next code is executed within the step
-    while (this.program[this.pc] === byteCodes.Input) {
+    if (this.program[this.pc] === byteCodes.Input) {
       const charCode = this.inputCnt < this.input.length ? this.input.charCodeAt(this.inputCnt) : 0
       this.memory.set(charCode)
-
       this.inputCnt++
-      this.pc++
     }
   }
 


### PR DESCRIPTION
This fixes bugs that `v` after `|:` and `:| is not evaluated.

Change: `v` consumes a step like `X`